### PR TITLE
Libsodium 1.0.16 is no longer hosted, use 1.0.17

### DIFF
--- a/res/libsodium/buildlibsodium.sh
+++ b/res/libsodium/buildlibsodium.sh
@@ -9,16 +9,16 @@ echo "Building libsodium"
 
 # Go into the lib sodium directory
 cd res/libsodium
-if [ ! -f libsodium-1.0.16.tar.gz ]; then
-    wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.16.tar.gz
+if [ ! -f libsodium-1.0.17.tar.gz ]; then
+    wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.17.tar.gz
 fi
 
-if [ ! -d libsodium-1.0.16 ]; then
-    tar xf libsodium-1.0.16.tar.gz
+if [ ! -d libsodium-1.0.17 ]; then
+    tar xf libsodium-1.0.17.tar.gz
 fi
 
 # Now build it
-cd libsodium-1.0.16
+cd libsodium-1.0.17
 LIBS="" ./configure
 make clean
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -29,4 +29,4 @@ fi
 cd ..
 
 # copy the library to the parents's res/ folder
-cp libsodium-1.0.16/src/libsodium/.libs/libsodium.a ../
+cp libsodium-1.0.17/src/libsodium/.libs/libsodium.a ../


### PR DESCRIPTION
Fixes the build, and the lib appears to be compatible.